### PR TITLE
clasp: correct package for quit

### DIFF
--- a/trivial-package-local-nicknames.lisp
+++ b/trivial-package-local-nicknames.lisp
@@ -28,7 +28,7 @@
     #+ccl   '(:ccl    :cc :quit)
     #+ecl   '(:ext    :ex :exit)
     #+abcl  '(:ext    :ex :quit)
-    #+clasp '(:ext    :ex :quit))
+    #+clasp '(:core   :ex :quit))
 
   (defparameter +pkg-name+ (first +test-data+))
   (defparameter +nn-name+ (second +test-data+))


### PR DESCRIPTION
* In clasp quit is defined in core:, not in ext:. 
* Package loads after this change, before fails with (error "Symbol not found while loading tests: check +SYM+ binding.")
* Running the tests shows some errors `;; 17 tests run, 6 failures.` will investigate further
